### PR TITLE
fix: RelationGraph

### DIFF
--- a/portal/src/components/Sidebar.tsx
+++ b/portal/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import {Layout, Menu} from 'antd';
 import * as React from 'react';
-import {ReactNode} from 'react';
+import {ReactNode, useMemo} from 'react';
 import {Link, useHistory} from 'react-router-dom';
 
 const menus = {
@@ -36,19 +36,23 @@ export function Sidebar(props: {
 }) {
 
     const history = useHistory();
-    const {Sider} = Layout;
-    const menuItems = getMenu(history.location.pathname);
+    const items = useMemo(
+        () => getMenu(history.location.pathname).map(i => <Menu.Item key={i.key}>
+            <Link to={i.link}/>{i.label}
+        </Menu.Item>),
+        [history.location.pathname]
+    );
 
     return <>
         <Layout>
-            <Sider width={320}
-                   breakpoint='lg'
-                   collapsedWidth={0}
+            <Layout.Sider width={320}
+                          breakpoint='lg'
+                          collapsedWidth={0}
             >
                 <Menu mode="inline" defaultSelectedKeys={[props.menuIndex]} style={{height: '100%', borderRight: 0}}>
-                    {menuItems.map(i => <Menu.Item key={i.key}><Link to={i.link}/>{i.label}</Menu.Item>)}
+                    {items}
                 </Menu>
-            </Sider>
+            </Layout.Sider>
             <Layout.Content>
                 {props.children}
             </Layout.Content>

--- a/portal/src/components/layout/Header.tsx
+++ b/portal/src/components/layout/Header.tsx
@@ -1,30 +1,10 @@
-import React, {ReactNode} from 'react';
+import React, {ReactNode, useMemo} from 'react';
 import {Col, Dropdown, Menu, Row} from 'antd';
 import './Header.css'
 import {MenuOutlined} from '@ant-design/icons';
 import {Link} from 'react-router-dom';
 import controlCiudadano from '../../assets/logos/control_ciudadano.svg';
 
-const menu = <Menu mode="horizontal" id="nav" key="nav">
-    <Menu.Item key="home">
-        <Link className="menu-item" to="/">Inicio</Link>
-    </Menu.Item>
-    <Menu.Item key="explorar">
-        <Link className="menu-item" to="/explore">Explorar Datos</Link>
-    </Menu.Item>
-    <Menu.Item key="analisis">
-        <Link className="menu-item" to="/action">Compras COVID</Link>
-    </Menu.Item>
-    <Menu.Item key="ddjj">
-        <Link className="menu-item" to="/djbr/portal">Declaraciones Juradas</Link>
-    </Menu.Item>
-    <Menu.Item key="conjunto">
-        <Link className="menu-item" to="/sources">Fuente de datos</Link>
-    </Menu.Item>
-    <Menu.Item key="docs">
-        <Link className="menu-item" to="/about">Acerca de</Link>
-    </Menu.Item>
-</Menu>;
 
 export function Header(props: {
     tableMode: boolean;
@@ -35,6 +15,27 @@ export function Header(props: {
     const showSeparator = props.showSeparator !== undefined
         ? props.showSeparator
         : props.tableMode;
+
+    const menu = useMemo(() => <Menu mode="horizontal" id="nav" key="nav">
+        <Menu.Item key="home">
+            <Link className="menu-item" to="/">Inicio</Link>
+        </Menu.Item>
+        <Menu.Item key="explorar">
+            <Link className="menu-item" to="/explore">Explorar Datos</Link>
+        </Menu.Item>
+        <Menu.Item key="analisis">
+            <Link className="menu-item" to="/action">Compras COVID</Link>
+        </Menu.Item>
+        <Menu.Item key="ddjj">
+            <Link className="menu-item" to="/djbr/portal">Declaraciones Juradas</Link>
+        </Menu.Item>
+        <Menu.Item key="conjunto">
+            <Link className="menu-item" to="/sources">Fuente de datos</Link>
+        </Menu.Item>
+        <Menu.Item key="docs">
+            <Link className="menu-item" to="/about">Acerca de</Link>
+        </Menu.Item>
+    </Menu>, []);
 
     return (props.tableMode
             ? <div id="header" className="header">

--- a/portal/src/components/sigma-react/FilterWithEdges.jsx
+++ b/portal/src/components/sigma-react/FilterWithEdges.jsx
@@ -7,36 +7,37 @@ import 'react-sigma/sigma/plugins.filter'
  * based on https://github.com/dunnock/react-sigma/blob/ea9d7932d8a018704f59f1ede1777963b6904989/src/Filter.js
  */
 class FilterWithEdges extends React.Component {
-  filter;
+    filter;
 
-  componentDidMount() {
-    this.filter = new sigma.plugins.filter(this.props.sigma)
-    this._apply(this.props)
-  }
-
-  componentWillUpdate(props) {
-    if (props.nodesBy !== this.props.nodesBy
-      || props.neighborsOf !== this.props.neighborsOf
-      || props.edgesBy !== this.props.edgesBy
-    )
-      this._apply(props)
-  }
-
-  render = () => null
-
-  _apply(props) {
-    this.filter.undo(["neighborsOf", "nodesBy", "edgesBy"])
-    if (props.neighborsOf) {
-      this.filter.neighborsOf(props.neighborsOf, "neighborsOf")
+    componentDidMount() {
+        this.filter = new sigma.plugins.filter(this.props.sigma)
+        this._apply(this.props)
     }
-    if (props.nodesBy)
-      this.filter.nodesBy(props.nodesBy, "nodesBy")
-    if (props.edgesBy)
-      this.filter.edgesBy(props.edgesBy, "edgesBy")
-    this.filter.apply()
-    if (this.props.sigma)
-      this.props.sigma.refresh();
-  }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.nodesBy !== this.props.nodesBy
+            || prevProps.neighborsOf !== this.props.neighborsOf
+            || prevProps.edgesBy !== this.props.edgesBy
+        )
+            this._apply(this.props)
+    }
+
+    render = () => null
+
+    _apply(props) {
+        console.log("Before: " + performance.now())
+        this.filter.undo(["neighborsOf", "nodesBy", "edgesBy"])
+        if (props.neighborsOf)
+            this.filter.neighborsOf(props.neighborsOf, "neighborsOf")
+        if (props.nodesBy)
+            this.filter.nodesBy(props.nodesBy, "nodesBy")
+        if (props.edgesBy)
+            this.filter.edgesBy(props.edgesBy, "edgesBy")
+        this.filter.apply()
+        if (this.props.sigma)
+            this.props.sigma.refresh();
+        console.log("After: " + performance.now())
+    }
 }
 
 export default FilterWithEdges;


### PR DESCRIPTION
The react-sigma doesn't support a change in it's graph parameter, so we
need to pass the loaded data and not a empty array and later the full
data.

In a previous change, the data was changed from a simple array to a
Async, but the condition to load the graph was the same, and a async is
never undefined so the graph was rendered without data.

Signed-off-by: Arturo Volpe <arturovolpe@gmail.com>