### PR TITLE
feat: Retry calls to comptroller API

### DIFF
--- a/scripts/python/airflow/dags/_csj_operators.py
+++ b/scripts/python/airflow/dags/_csj_operators.py
@@ -1,8 +1,5 @@
 from typing import List
 
-import requests
-from bs4 import BeautifulSoup
-
 from _muni_operators import get_target_path
 from _policia_operators import _get_links, only_files
 from network_operators import download_links


### PR DESCRIPTION
In some cases, the API returns invalid data like:

```json
{
  "id": 1711248,
  "idCabeceraDjb": 986121,
  "nombres": "CELSO ESPINOLA CARDOZO",
  "cedula": null,
  "fecha": "2021-12-28T13:58:21.037+0000",
  "nombreArchivo": null,
  "path": null,
  "fisico": false,
  "periodo": 2021
}
```

This data can't be parsed because the document is null,
we skip those lines for now, in the future we will need to
store that in other table.

Signed-off-by: Arturo Volpe <arturovolpe@gmail.com>
